### PR TITLE
fix: find_unique_name edge case

### DIFF
--- a/pipeline_dash/viz/dash/components/jobs_pipeline_fig.py
+++ b/pipeline_dash/viz/dash/components/jobs_pipeline_fig.py
@@ -167,6 +167,7 @@ def generate_node_traces(graph):
     def find_unique_in_name(a: str, b: str):
         al = a.split("-")
         bl = b.split("-")
+        al, bl = (bl, al) if len(al) > len(bl) else (al, bl)
         i = 0
         for i, t in enumerate(al):
             if t != bl[i]:


### PR DESCRIPTION
`find_unique_name` implementation assumed that the tokenized `al` list is the same or smaller length than the `bl` list. This commmit fixes `find_unique_name` for when `bl` has a smaller length than `al`.