### PR TITLE
feat: ability to generate hyperlinks instead of full jenkins link

### DIFF
--- a/pipeline_dash/main.py
+++ b/pipeline_dash/main.py
@@ -116,6 +116,7 @@ def help(ctx, subcommand):
 @click.option("--verbose", is_flag=True, help="Show verbose output")
 @click.option("--debug", is_flag=True, help="Turn on debug features (verbose logging, inspection features, etc)")
 @click.option("--cli-report", is_flag=True, help="Generate a text-based report rather than graph visualization")
+@click.option("--short-links", is_flag=True, help="Use hyperlinks instead of full jenkins links (may not work in all terminals)")
 @click.option(
     "--cache",
     help="Directory to cache data",
@@ -131,7 +132,7 @@ def help(ctx, subcommand):
     show_default=True,
 )
 @click.option("--user-file", help="User file if server authentication is required", type=click.Path(exists=True))
-def dash(pipeline_config, user_file, recurse, verbose, cli_report, cache, store, load, auth, debug):
+def dash(pipeline_config, user_file, recurse, verbose, cli_report, short_links, cache, store, load, auth, debug):
     import diskcache  # type: ignore
 
     dcache = diskcache.Cache(".diskcache")
@@ -206,7 +207,7 @@ def dash(pipeline_config, user_file, recurse, verbose, cli_report, cache, store,
     # elements = generate_cyto_elements(pipeline_dict, job_data)
     # display_cyto(elements)
     if cli_report:
-        display_rich_table(pipeline_dicts, job_data, load, store)
+        display_rich_table(pipeline_dicts, job_data, load, store, short_links)
     else:
         display_dash(
             get_job_data_,

--- a/pipeline_dash/viz/viz_rich.py
+++ b/pipeline_dash/viz/viz_rich.py
@@ -17,6 +17,7 @@ def add_jobs_to_table(
     progress_task_fn: Callable,
     load_dir: Optional[str],
     store_dir: Optional[str],
+    short_links: bool
 ):
     def status(job_status: JobStatus):
         if job_status is JobStatus.UNDEFINED:
@@ -31,6 +32,9 @@ def add_jobs_to_table(
         elif job_status == JobStatus.FAILURE:
             text.stylize("bold red3")
         return text
+
+    def link(name: str, url: str):
+        return f'[link={url}]{name}[/link]'
 
     def add_prefix(prefix: str) -> str:
         if not len(prefix):
@@ -54,7 +58,7 @@ def add_jobs_to_table(
             fields.build_num,
             fields.timestamp.strftime("%y-%m-%d %H:%M UTC") if fields.timestamp else None,
             status(fields.status),
-            fields.url,
+            link("Jenkins Link", fields.url) if short_links else fields.url
         )
         if fields.timestamp and datetime.now() - fields.timestamp > timedelta(hours=24):
             table.rows[-1].style = "dim"
@@ -73,6 +77,7 @@ def add_jobs_to_table(
             progress_task_fn=progress_task_fn,
             load_dir=load_dir,
             store_dir=store_dir,
+            short_links=short_links,
         )
         prefix = remove_prefix(prefix)
 
@@ -81,7 +86,7 @@ def count_dict(d):
     return sum([count_dict(v) if isinstance(v, dict) else 1 for v in d.values()])
 
 
-def display_rich_table(pipeline_dict, job_data, load, store):
+def display_rich_table(pipeline_dict, job_data, load, store, short_links):
     console = rich.console.Console()
     other_table = rich.table.Table(title="Jobs")
     other_table.add_column("Name")
@@ -103,5 +108,6 @@ def display_rich_table(pipeline_dict, job_data, load, store):
                 progress_task_fn=progress_fn,
                 load_dir=load,
                 store_dir=store,
+                short_links=short_links
             )
     console.print(other_table)


### PR DESCRIPTION
hyperlinks are fairly well supported, but since it's not guaranteed and failure will just result in unclickable text with no clue what the link was I left `--short-links` off by default